### PR TITLE
Update downloads/guis, based on availability and active development

### DIFF
--- a/app/views/downloads/guis/index.html.haml
+++ b/app/views/downloads/guis/index.html.haml
@@ -35,6 +35,18 @@
         %p.description
           <strong>Platforms:</strong> Windows, Mac</br>
           <strong>Price:</strong> Free
+      %li.mac.windows.linux
+        =link_to(image_tag('guis/git-kraken@2x.png', {:width => '294', :height => '166'}), "https://www.gitkraken.com/")
+        %h4= link_to "GitKraken", "https://www.gitkraken.com/"
+        %p.description
+          <strong>Platforms:</strong> Windows, Mac, Linux</br>
+          <strong>Price:</strong> Free for non-commercial use
+      %li.mac.windows
+        =link_to(image_tag('guis/tower@2x.png', {:width => '294', :height => '166'}), "https://www.git-tower.com/")
+        %h4= link_to "Tower", "https://www.git-tower.com/"
+        %p.description
+          <strong>Platforms:</strong> Windows, Mac</br>
+          <strong>Price:</strong> $79/user (Free 30 day trial)
       %li.windows
         =link_to(image_tag('guis/tortoisegit@2x.png', {:width => '294', :height => '166'}), "https://tortoisegit.org/")
         %h4= link_to "TortoiseGit", "https://tortoisegit.org/"
@@ -42,35 +54,11 @@
           <strong>Platforms:</strong> Windows</br>
           <strong>Price:</strong> Free
       %li.mac.windows.linux
-        =link_to(image_tag('guis/git-kraken@2x.png', {:width => '294', :height => '166'}), "https://www.gitkraken.com/")
-        %h4= link_to "GitKraken", "https://www.gitkraken.com/"
-        %p.description
-          <strong>Platforms:</strong> Windows, Mac, Linux</br>
-          <strong>Price:</strong> Free for non-commercial use
-      %li.mac
-        =link_to(image_tag('guis/gitup@2x.png', {:width => '294', :height => '166'}), "http://gitup.co/")
-        %h4= link_to "GitUp", "http://gitup.co/"
-        %p.description
-          <strong>Platforms:</strong> Mac</br>
-          <strong>Price:</strong> Free
-      %li.mac.windows.linux
         =link_to(image_tag('guis/smartgit@2x.png', {:width => '294', :height => '166'}), "https://www.syntevo.com/smartgit/")
         %h4= link_to "SmartGit", "https://www.syntevo.com/smartgit/"
         %p.description
           <strong>Platforms:</strong> Windows, Mac, Linux</br>
           <strong>Price:</strong> $79/user / Free for non-commercial use
-      %li.windows
-        =link_to(image_tag('guis/git-extensions@2x.png', {:width => '294', :height => '166'}), "https://gitextensions.github.io/")
-        %h4= link_to "Git Extensions", "https://gitextensions.github.io/"
-        %p.description
-          <strong>Platforms:</strong> Windows</br>
-          <strong>Price:</strong> Free
-      %li.mac.windows
-        =link_to(image_tag('guis/tower@2x.png', {:width => '294', :height => '166'}), "https://www.git-tower.com/")
-        %h4= link_to "Tower", "https://www.git-tower.com/"
-        %p.description
-          <strong>Platforms:</strong> Windows, Mac</br>
-          <strong>Price:</strong> $79/user (Free 30 day trial)
       %li.windows.linux
         =link_to(image_tag('guis/gitg@2x.png', {:width => '294', :height => '166'}), "https://wiki.gnome.org/Apps/Gitg/")
         %h4= link_to "gitg", "https://wiki.gnome.org/Apps/Gitg/"
@@ -80,6 +68,18 @@
       %li.mac
         =link_to(image_tag('guis/gitx@2x.png', {:width => '294', :height => '166'}), "https://rowanj.github.io/gitx/")
         %h4= link_to "GitX-dev ", "https://rowanj.github.io/gitx/"
+        %p.description
+          <strong>Platforms:</strong> Mac</br>
+          <strong>Price:</strong> Free
+      %li.windows
+        =link_to(image_tag('guis/git-extensions@2x.png', {:width => '294', :height => '166'}), "https://gitextensions.github.io/")
+        %h4= link_to "Git Extensions", "https://gitextensions.github.io/"
+        %p.description
+          <strong>Platforms:</strong> Windows</br>
+          <strong>Price:</strong> Free
+      %li.mac
+        =link_to(image_tag('guis/gitup@2x.png', {:width => '294', :height => '166'}), "http://gitup.co/")
+        %h4= link_to "GitUp", "http://gitup.co/"
         %p.description
           <strong>Platforms:</strong> Mac</br>
           <strong>Price:</strong> Free
@@ -95,12 +95,6 @@
         %p.description
           <strong>Platforms:</strong> Windows, Mac, Linux</br>
           <strong>Price:</strong> Free
-      %li.mac
-        =link_to(image_tag('guis/gitbox@2x.png', {:width => '294', :height => '166'}), "http://www.gitboxapp.com/")
-        %h4= link_to "Gitbox", "http://www.gitboxapp.com/"
-        %p.description
-          <strong>Platforms:</strong> Mac</br>
-          <strong>Price:</strong> $14.99
       %li.mac.windows.linux
         =link_to(image_tag('guis/cycligent@2x.png', {:width => '294', :height => '166'}), "https://www.cycligent.com/git-tool")
         %h4= link_to "Cycligent Git Tool", "https://www.cycligent.com/git-tool"
@@ -131,6 +125,12 @@
         %p.description
           <strong>Platforms:</strong> Linux</br>
           <strong>Price:</strong> Free
+      %li.mac
+        =link_to(image_tag('guis/gitbox@2x.png', {:width => '294', :height => '166'}), "http://www.gitboxapp.com/")
+        %h4= link_to "Gitbox", "http://www.gitboxapp.com/"
+        %p.description
+          <strong>Platforms:</strong> Mac</br>
+          <strong>Price:</strong> $14.99
 
   %div.callout
     %p


### PR DESCRIPTION
- Gitbox: abandoned, last update in 2012
- GitUp: Mac only, not under active development (https://github.com/git-up/GitUp/issues)
- TortoiseGit and Git Extensions: both Windows only